### PR TITLE
Fix for OUJS

### DIFF
--- a/YoutubeWatched.user.js
+++ b/YoutubeWatched.user.js
@@ -5,7 +5,7 @@
 // @namespace    https://github.com/highstrike/youtube-watched
 // @version      4.1
 // @author       Highstrike
-// @license      GPL; http://www.gnu.org/licenses/gpl.html
+// @license      GPL-3.0+; http://www.gnu.org/licenses/gpl.html
 // @require      https://code.jquery.com/jquery-2.2.4.min.js
 // @match        *://www.youtube.com/*
 // @grant        none


### PR DESCRIPTION
OUJS has made a change recently to require SPDX codes for OSI approved licensing.

In order to improve the appearance of your script homepage it would be appreciated if you could modify your affected script.

Until this change is made you will be unable to update those affected scripts.

Thanks,
OUJS Staff